### PR TITLE
Prevent recursive MATLAB/Python re-entry when MATLAB launches main.py

### DIFF
--- a/Structures Analysis/obtain_vehicle_parameters.m
+++ b/Structures Analysis/obtain_vehicle_parameters.m
@@ -3,7 +3,7 @@ cd('C:..')
 
 python_executable_path = "python";
 python_script_path = "main.py";
-[exit_status, command_output] = system(python_executable_path + " " + python_script_path);
+[exit_status, command_output] = system("set PSPL_INVOKED_BY_MATLAB=1 && " + python_executable_path + " " + python_script_path);
 
 % fprintf("exit_status: %d\n", exit_status);
 % fprintf("command_output:\n%s\n", command_output);


### PR DESCRIPTION
### Motivation
- MATLAB calls `main.py` to obtain vehicle parameters but that Python script previously launched MATLAB again, creating a recursive re-entry loop; the change prevents that recursion.

### Description
- Added an invocation guard in `main.py` that checks the environment variable `PSPL_INVOKED_BY_MATLAB` and skips launching MATLAB when it is set. 
- Updated `main.py` to use `structures_analysis_path` for writing `wet_mass_distribution.mat` and to conditionally avoid loading `structural_loads.mat` when invoked by MATLAB. 
- Modified `Structures Analysis/obtain_vehicle_parameters.m` to set `PSPL_INVOKED_BY_MATLAB=1` when calling `python main.py` so MATLAB can still run Python without triggering Python to spawn MATLAB again. 
- Kept standalone behavior unchanged: running `main.py` directly still launches MATLAB with `matlab -batch` to run `Full_Rocket_Analysis.m`.

### Testing
- Ran `python -m py_compile main.py`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d72c7e8b48331bea6b08bbedb4962)